### PR TITLE
Fix issue with extracting mod .zips

### DIFF
--- a/HeavyModManager/Functions/ZipManager.cs
+++ b/HeavyModManager/Functions/ZipManager.cs
@@ -42,6 +42,12 @@ public static class ZipManager
 
         foreach (var entry in zip.Entries)
         {
+            // If the entry is a directory, FullName ends with '/'
+            // Can skip directories since they are created below
+            // - Pepperpot
+            if (entry.FullName.EndsWith('/'))
+                continue;
+
             var destinationPath = Path.Combine(modPath, entry.FullName);
 
             var destFolder = Path.GetDirectoryName(destinationPath);


### PR DESCRIPTION
Fix issue #4 where an exception would be thrown if a zip's entries contains directories